### PR TITLE
Fixed permissions on generated stats files

### DIFF
--- a/local/ArenaServer.py
+++ b/local/ArenaServer.py
@@ -875,5 +875,4 @@ class ArenaServer:
         data = {'players': stats, 'gameLength': gameLength}
         statsfile.write(dumps(data))
         statsfile.close()
-        from stat import S_IROTH
-        os.chmod(filename, S_IROTH)
+        os.chmod(filename, 0o666)


### PR DESCRIPTION
Instead of using the python flags for permissions in the stat module I used the exact octal value we needed (666)